### PR TITLE
Поддержка Vesktop'a

### DIFF
--- a/main.py
+++ b/main.py
@@ -121,7 +121,7 @@ class Presence:
     running = False
     paused = False
     paused_time = 0 
-    exe_names = ["Discord.exe", "DiscordCanary.exe", "DiscordPTB.exe"]
+    exe_names = ["Discord.exe", "DiscordCanary.exe", "DiscordPTB.exe", "Vesktop.exe"]
 
     @staticmethod
     def is_discord_running() -> bool:


### PR DESCRIPTION
#72 
Добавил "Vesktop.exe" в переменную exe_names, иначе он просто пишет, что Дискорд не запущен. Внутри Vesktop'а функционал, после изменения, исправно работает. Скриншот из Vekstop'a прикладываю:

![Снимок экрана 2024-10-26 192220](https://github.com/user-attachments/assets/8541c4d5-a746-4870-9dd7-2d216b6a33e4)
